### PR TITLE
Updated deprecated gripper controller

### DIFF
--- a/mp_bringup/configs/ur/simulation_controllers.yaml
+++ b/mp_bringup/configs/ur/simulation_controllers.yaml
@@ -28,10 +28,10 @@ controller_manager:
       type: position_controllers/JointGroupPositionController
 
     robotiq_2f_140_gripper_controller:
-      type: position_controllers/GripperActionController
+      type: parallel_gripper_action_controller/GripperActionController
 
     robotiq_2f_85_gripper_controller:
-      type: position_controllers/GripperActionController
+      type: parallel_gripper_action_controller/GripperActionController
 
 speed_scaling_state_broadcaster:
   ros__parameters:


### PR DESCRIPTION
The gripper controllers were updated.  Just like ROX, the gripper in simulation is buggy for Rolling. Needs to be tested in Jazzy and Kilted